### PR TITLE
fix watched status updates

### DIFF
--- a/app/assets/javascripts/updateStatus.js
+++ b/app/assets/javascripts/updateStatus.js
@@ -1,16 +1,36 @@
-function updateStatus(id, status) {
-  $.ajax({
-    method: "PATCH",
-    url: "/api/v1/movies/" + id,
-    data: { id: id, watched: status},
-    success: function(){
-      if(status === true) {
-        $("#watched-" + id).hide();
-        $("#unwatched-" + id).show();
-      } else {
-        $("#unwatched-" + id).hide();
-        $("#watched-" + id).show();
+function updateStatus(){
+  $('.watched').on("click", function(event){
+    var button = event.target;
+    //grab id of button
+    var movieId = button.getAttribute('id');
+    $.ajax({
+      method: "PATCH",
+      url: "/api/v1/movies/update_watched_status",
+      data: { id: movieId },
+      dataType: "json",
+      success: function(movie){
+        updateButtonText(movie, button);
+        updateRowColor(movie, button);
       }
-    }
+    });
   });
+}
+
+function updateButtonText(movie, button){
+  if (movie.watched === true) {
+    button.innerText = "Mark as Unwatched";
+  } else {
+    button.innerText = "Mark as Watched";
+  }
+}
+
+function updateRowColor(movie, button){
+  var row = button.parentElement.parentElement;
+  if (movie.watched === true) {
+    row.setAttribute("data-status", "Watched");
+    row.style.backgroundColor= "lightgray";
+  } else {
+    row.setAttribute("data-status", "Unwatched");
+    row.style.backgroundColor = "lightgreen";
+  }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,10 +16,10 @@
  @import "bootstrap-sprockets";
  @import "bootstrap";
 
- .watched {
+ .Watched {
   background-color: lightgray;
 }
 
-.unwatched {
+.Unwatched {
   background-color: lightgreen;
 }

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -5,14 +5,10 @@ class Api::V1::MoviesController < ApplicationController
     render json: @movies
   end
 
-  def update(movie_params)
-    movie = Movie.find[params[:id]]
-    if params[:watched]
-      movie.watched = !movie.watched
-      movie.update(movie_params)
-      movie.save
-      render json: movie
-    end
+  def update
+    @movie = Movie.find(params[:id])
+    @movie.update_watched_status
+    render json: @movie
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,19 @@
 module ApplicationHelper
+
+  def check_watched_status(status)
+    if status == true
+      "Watched"
+    else
+      "Unwatched"
+    end
+  end
+
+  def watched_button_text(status)
+    if status == true
+      "Mark as Unwatched"
+    else
+      "Mark as Watched"
+    end
+  end
+
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -3,4 +3,17 @@ class Movie < ApplicationRecord
   validates :title, presence: true
 
   belongs_to :user
+
+  def update_watched_status
+    if self.watched == true
+      update_attribute(:watched, false)
+    else
+      update_attribute(:watched, true)
+    end
+  end
+
+  def self.alphabetize_movies(user)
+    where("user_id = #{user.id}")
+    .order("movies.title")
+  end
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -35,7 +35,7 @@
 
 <p></p>
 <p></p>
-<div id="return-data" class="panel panel-default">
+  <div id="return-data" class="panel panel-default">
     <h2>All My Movies</h2>
     <table id="movies-list" class="table">
     <thead>
@@ -51,32 +51,19 @@
     <tbody id="movies-table">
 
         <% current_user.movies.each do |movie| %>
-          <% if movie.watched %>
-            <tr raw-id="<%= movie.id %>" id="movie-<%= movie.id %>" class="movie watched" data-status="Watched">
+            <tr raw-id="<%= movie.id %>" id="movie-<%= movie.id %>" class="movie <%=check_watched_status(movie.watched)%>" data-status="<%=check_watched_status(movie.watched)%>">
               <td class="movie-title"><%= movie.title %></td>
               <td class="movie-note"><%= movie.note %></td>
               <td class="movie-tag"><%= render movie.tags %></td>
-              <td class="movie-status" id="watched-status"><%= link_to "Mark as Unwatched", movie_path(movie, watched: false), method: :patch %>
+              <td class="movie-status" id="watched-status">
+                <button class="watched btn btn-default btn-xs" id="<%= movie.id%>"> <%=watched_button_text(movie.watched)%></button>
               </td>
               <td><%= link_to "Edit", edit_movie_path(movie) %></td>
               <td><%= link_to "Delete", movie_path(movie), method: :delete %></td>
             </tr>
-          <% else %>
-            <tr raw-id="<%= movie.id %>" id="movie-<%= movie.id %>" class="movie unwatched" data-status="Unwatched">
-              <td class="movie-title"><%= movie.title %></td>
-              <td class="movie-note"><%= movie.note %></td>
-                <td class="movie-tag"><%= render movie.tags %></td>
-              <td class="movie-status" id="watched-status"><%= link_to "Mark as Watched", movie_path(movie, watched: true), method: :patch %>
-              </td>
-              <td><%= link_to "Edit", edit_movie_path(movie) %></td>
-              <td><%= link_to "Delete", movie_path(movie), method: :delete %></td>
-            </tr>
-          <% end %>
         <% end %>
 
     </tbody>
-</table>
-
+    </table>
   </div>
-
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
   root to: "home#show"
 
-  namespace :api do
+  namespace :api, defaults: { format: :json } do
     namespace :v1 do
+      patch '/movies/update_watched_status', to: 'movies#update'
       get '/movies/alphabetize_movies', to: 'movies#index'
       resources :movies, only: [:index, :update]
     end

--- a/spec/features/user_can_update_watched_status_spec.rb
+++ b/spec/features/user_can_update_watched_status_spec.rb
@@ -1,22 +1,35 @@
 require "rails_helper"
 
-RSpec.feature "User updates watched status for movie" do
-  context "has valid attributes" do
-    scenario "movie is added to movie table on home page" do
+RSpec.feature "User updates watched status for movie", js: true do
+  context "movie is added to movie table on home page" do
+    scenario "selecting watched button updates status" do
       user = create(:user, email: "deb@tnemail.com", password: "password")
       login(user)
 
       fill_in "Title", with: "Harry and the Hendersons"
       fill_in "Note", with: "So adorable."
       click_on "Add new movie"
-      expect(page).to have_css '.unwatched'
 
-      click_on "Mark as Watched"
+      expect(page).to have_content("Harry and the Hendersons")
+      expect(page).to have_content("So adorable.")
+      expect(page).to have_button("Mark as Watched")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-      expect(page).to have_content "Mark as Unwatched"
-      expect(page).to have_css '.watched'
-      expect(page).to_not have_content "Mark as Watched"
-      expect(page).to_not have_css '.unwatched'
+      within("#movies-table tr:nth-child(1)") do
+        expect(page).to have_button("Mark as Watched")
+        expect(page).not_to have_button("Mark as Unwatched")
+        expect(page).not_to have_selector("#unwatched")
+
+        click_on "Mark as Watched"
+
+        expect(page).to have_button("Mark as Unwatched")
+        expect(page).not_to have_button("Mark as Watched")
+
+        click_on "Mark as Unwatched"
+
+        expect(page).to have_button("Mark as Watched")
+        expect(page).not_to have_button("Mark as Unwatched")
+      end
     end
   end
 end

--- a/spec/requests/api/v1/movies_controller_spec.rb
+++ b/spec/requests/api/v1/movies_controller_spec.rb
@@ -1,42 +1,22 @@
 require 'rails_helper'
 
-describe "All Movies" do
-
-	context "#Index" do
-		xit 'can return all links' do
-			user = User.create(email: 'bernie@tnemail.com', password: 'password')
-			added_link = user.links.create(title: 'Berney Sanders', url: 'http://berniesanders.com')
-
-			get "/api/v1/links"
-
-			links = JSON.parse(response.body)
-			link = links.first
-
-			expect(response).to be_success
-			expect(link['title']).to eq(added_link.title)
-			expect(link['url']).to eq(added_link.url)
-			expect(link['read']).to eq(added_link.read)
-			expect(link['user_id']).to eq(added_link.user_id)
-
-		end
-  end
+describe "Movies API" do
 
 	context "#Update" do
-		xit 'can update a single movie' do
+		it 'can update a single movie' do
 			user = User.create(email: 'bernie@tnemail.com', password: 'password')
 			added_movie = user.movies.create(title: 'Wizard of Oz', note: 'Make believe and flying monkeys')
 			params = { title: 'Ghostbusters', note: 'When there is something weird', watched: true }
+			id = added_movie.id
 
-			post "/api/v1/users/#{user.id}/movies/#{added_movie.id}", movie: params
-
-			movies = JSON.parse(response.body)
-			movie = movies.first
+			patch "/api/v1/movies/#{id}", movie: {watched: true}
 
 			expect(response).to be_success
-			expect(movie['title']).to eq('Ghostbusters')
-			expect(movie['note']).to eq('When there is something weird')
-			expect(movie['watched']).to eq(true)
-			expect(movie['user_id']).to eq(added_movie.user_id)
+
+			json = JSON.parse(response.body)
+
+			expect(json['watched']).to eq(true)
+			expect(Movie.find(id).watched).to eq(true)
 		end
 	end
 


### PR DESCRIPTION
@carmer - Please review my fix. I think it works!! 

* Refactored #movies-table and edited updateStatus.js to 
* Allows the watched/unwatched status to be changed via client side code vs an http request response cycle.

FIX: Watched/unwatched links were originally explicitly set to pass the watched update to the movie_path with a method: :patch in the html. This required reloading of the page. There was also a couple of problems in the movies controller update action. Fixed syntax, errors and pulled watched logic out into new helpers and functions.

* refactor movies table to remove redundant code
* remove erb conditional logic from table in index.html.erb
* add helper method to check_watched_status
* add new button and helper to change watched_button_text
	* this replaced link_to and request path logic and helped enable change in client side code
* edit updateStatus.js
	* add event listener to watched button
	* add custom route and method to update_watched_status
	* add new functions to updateButtonText and updateRowColor on success

TESTS:
	* update feature spec -  user_can_update_watched_status_spec.rb
	* update request spec - movies_controller_spec.rb
	* All tests passing